### PR TITLE
Improve error handling

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -51,7 +51,12 @@ pub fn read_file() -> Result<IndexMap<String, Info>> {
     std::fs::create_dir_all(&dir)?;
 
     match File::open(format!("{}/{}", dir, DATA_FILENAME)) {
-        Err(_) => Ok(IndexMap::new()),
+        Err(e) => {
+            match e.kind() {
+                std::io::ErrorKind::NotFound => Ok(IndexMap::new()),
+                _ => Err(BucketListError::from(e)),
+            }
+        },
         Ok(file) => {
             let reader = BufReader::new(file);
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -17,7 +17,7 @@ type Result<T> = std::result::Result<T, BucketListError>;
 pub enum BucketListError {
     #[error("No such an item (name: `{0}`).")]
     NotFoundError(String),
-    #[error("Failed to convert home directory to str.")]
+    #[error("Failed to get home directory.")]
     HomeDirError,
     #[error("I/O related error happened.")]
     IoError(#[from] std::io::Error),
@@ -36,14 +36,12 @@ pub struct Info {
 }
 
 pub fn read_file() -> Result<IndexMap<String, Info>> {
-    let dir = match dirs::home_dir() {
-        None => format!("./{}", CONFIG_DIRNAME),
-        Some(home) => format!(
-            "{}/{}",
-            home.to_str().ok_or(BucketListError::HomeDirError)?,
-            CONFIG_DIRNAME
-        ),
-    };
+    let dir = format!(
+        "{}/{}",
+        dirs::home_dir().ok_or(BucketListError::HomeDirError)?
+            .to_str().ok_or(BucketListError::HomeDirError)?,
+        CONFIG_DIRNAME
+    );
     std::fs::create_dir_all(&dir)?;
 
     match File::open(format!("{}/{}", dir, DATA_FILENAME)) {
@@ -69,14 +67,12 @@ pub fn read_file() -> Result<IndexMap<String, Info>> {
 }
 
 pub fn save_file(items: IndexMap<String, Info>) -> Result<()> {
-    let dir = match dirs::home_dir() {
-        None => format!("./{}", CONFIG_DIRNAME),
-        Some(home) => format!(
-            "{}/{}",
-            home.to_str().ok_or(BucketListError::HomeDirError)?,
-            CONFIG_DIRNAME
-        ),
-    };
+    let dir = format!(
+        "{}/{}",
+        dirs::home_dir().ok_or(BucketListError::HomeDirError)?
+            .to_str().ok_or(BucketListError::HomeDirError)?,
+        CONFIG_DIRNAME
+    );
 
     let file = OpenOptions::new()
         .write(true)

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,6 +11,8 @@ const DECAY: f32 = 0.925;
 const SEC_OF_DECAY: u64 = 86400;
 const ACTIVE_THRESHOLD: f32 = 0.1;
 
+type Result<T> = std::result::Result<T, BucketListError>;
+
 #[derive(Debug, Error)]
 pub enum BucketListError {
     #[error("No such an item (name: `{0}`).")]
@@ -33,7 +35,7 @@ pub struct Info {
     note: String,
 }
 
-pub fn read_file() -> Result<IndexMap<String, Info>, BucketListError> {
+pub fn read_file() -> Result<IndexMap<String, Info>> {
     let dir = match dirs::home_dir() {
         None => format!("./{}", CONFIG_DIRNAME),
         Some(home) => format!(
@@ -66,7 +68,7 @@ pub fn read_file() -> Result<IndexMap<String, Info>, BucketListError> {
     }
 }
 
-pub fn save_file(items: IndexMap<String, Info>) -> Result<(), BucketListError> {
+pub fn save_file(items: IndexMap<String, Info>) -> Result<()> {
     let dir = match dirs::home_dir() {
         None => format!("./{}", CONFIG_DIRNAME),
         Some(home) => format!(
@@ -87,7 +89,7 @@ pub fn save_file(items: IndexMap<String, Info>) -> Result<(), BucketListError> {
     Ok(())
 }
 
-pub fn add_or_incr(mut items: IndexMap<String, Info>, name: String) -> Result<IndexMap<String, Info>, BucketListError> {
+pub fn add_or_incr(mut items: IndexMap<String, Info>, name: String) -> Result<IndexMap<String, Info>> {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)?
         .as_secs();
@@ -112,7 +114,7 @@ pub fn add_or_incr(mut items: IndexMap<String, Info>, name: String) -> Result<In
     Ok(items)
 }
 
-pub fn note(mut items: IndexMap<String, Info>, name: String, note: String) -> Result<IndexMap<String, Info>, BucketListError> {
+pub fn note(mut items: IndexMap<String, Info>, name: String, note: String) -> Result<IndexMap<String, Info>> {
     match items.get_mut(&name) {
         None => Err(BucketListError::NotFoundError(name)),
         Some(info) => {
@@ -123,7 +125,7 @@ pub fn note(mut items: IndexMap<String, Info>, name: String, note: String) -> Re
     }
 }
 
-pub fn del(mut items: IndexMap<String, Info>, name: String) -> Result<IndexMap<String, Info>, BucketListError> {
+pub fn del(mut items: IndexMap<String, Info>, name: String) -> Result<IndexMap<String, Info>> {
     match items.remove(&name) {
         None => Err(BucketListError::NotFoundError(name)),
         Some(info) => {
@@ -134,7 +136,7 @@ pub fn del(mut items: IndexMap<String, Info>, name: String) -> Result<IndexMap<S
     }
 }
 
-pub fn ls(mut items: IndexMap<String, Info>, all: bool) -> Result<IndexMap<String, Info>, BucketListError> {
+pub fn ls(mut items: IndexMap<String, Info>, all: bool) -> Result<IndexMap<String, Info>> {
     items.sort_by(
         |_, v1, _, v2| 
             v1.prio.partial_cmp(&v2.prio).unwrap().reverse()

--- a/src/app.rs
+++ b/src/app.rs
@@ -35,13 +35,19 @@ pub struct Info {
     note: String,
 }
 
+fn get_bucketlist_dir() -> Result<String> {
+    Ok(
+        format!(
+            "{}/{}",
+            dirs::home_dir().ok_or(BucketListError::HomeDir)?
+                .to_str().ok_or(BucketListError::HomeDir)?,
+            CONFIG_DIRNAME
+        )
+    )
+}
+
 pub fn read_file() -> Result<IndexMap<String, Info>> {
-    let dir = format!(
-        "{}/{}",
-        dirs::home_dir().ok_or(BucketListError::HomeDir)?
-            .to_str().ok_or(BucketListError::HomeDir)?,
-        CONFIG_DIRNAME
-    );
+    let dir = get_bucketlist_dir()?;
     std::fs::create_dir_all(&dir)?;
 
     match File::open(format!("{}/{}", dir, DATA_FILENAME)) {
@@ -67,12 +73,7 @@ pub fn read_file() -> Result<IndexMap<String, Info>> {
 }
 
 pub fn save_file(items: IndexMap<String, Info>) -> Result<()> {
-    let dir = format!(
-        "{}/{}",
-        dirs::home_dir().ok_or(BucketListError::HomeDir)?
-            .to_str().ok_or(BucketListError::HomeDir)?,
-        CONFIG_DIRNAME
-    );
+    let dir = get_bucketlist_dir()?;
 
     let file = OpenOptions::new()
         .write(true)

--- a/src/app.rs
+++ b/src/app.rs
@@ -16,15 +16,15 @@ type Result<T> = std::result::Result<T, BucketListError>;
 #[derive(Debug, Error)]
 pub enum BucketListError {
     #[error("No such an item (name: `{0}`).")]
-    NotFoundError(String),
+    NotFound(String),
     #[error("Failed to get home directory.")]
-    HomeDirError,
+    HomeDir,
     #[error("I/O related error happened.")]
-    IoError(#[from] std::io::Error),
+    Io(#[from] std::io::Error),
     #[error("Time related error happened.")]
-    TimeError(#[from] std::time::SystemTimeError),
+    Time(#[from] std::time::SystemTimeError),
     #[error("Serde related error happened.")]
-    SeredeError(#[from] serde_json::Error),
+    Serde(#[from] serde_json::Error),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -38,8 +38,8 @@ pub struct Info {
 pub fn read_file() -> Result<IndexMap<String, Info>> {
     let dir = format!(
         "{}/{}",
-        dirs::home_dir().ok_or(BucketListError::HomeDirError)?
-            .to_str().ok_or(BucketListError::HomeDirError)?,
+        dirs::home_dir().ok_or(BucketListError::HomeDir)?
+            .to_str().ok_or(BucketListError::HomeDir)?,
         CONFIG_DIRNAME
     );
     std::fs::create_dir_all(&dir)?;
@@ -69,8 +69,8 @@ pub fn read_file() -> Result<IndexMap<String, Info>> {
 pub fn save_file(items: IndexMap<String, Info>) -> Result<()> {
     let dir = format!(
         "{}/{}",
-        dirs::home_dir().ok_or(BucketListError::HomeDirError)?
-            .to_str().ok_or(BucketListError::HomeDirError)?,
+        dirs::home_dir().ok_or(BucketListError::HomeDir)?
+            .to_str().ok_or(BucketListError::HomeDir)?,
         CONFIG_DIRNAME
     );
 
@@ -112,7 +112,7 @@ pub fn add_or_incr(mut items: IndexMap<String, Info>, name: String) -> Result<In
 
 pub fn note(mut items: IndexMap<String, Info>, name: String, note: String) -> Result<IndexMap<String, Info>> {
     match items.get_mut(&name) {
-        None => Err(BucketListError::NotFoundError(name)),
+        None => Err(BucketListError::NotFound(name)),
         Some(info) => {
             info.note = note;
             println!("The note of `{}` is upated.", name);
@@ -123,7 +123,7 @@ pub fn note(mut items: IndexMap<String, Info>, name: String, note: String) -> Re
 
 pub fn del(mut items: IndexMap<String, Info>, name: String) -> Result<IndexMap<String, Info>> {
     match items.remove(&name) {
-        None => Err(BucketListError::NotFoundError(name)),
+        None => Err(BucketListError::NotFound(name)),
         Some(info) => {
             println!("`{}` is deleted.", name);
             log::info!("{:#?}", info);

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,9 @@ mod app;
 #[derive(Parser, Debug)]
 #[clap(
     version,
-    about = "Bucket List CLI", 
-    long_about = "Provides an bucket list prioritizing items automatically.")]
+    about = "Bucket List CLI",
+    long_about = "Provides an bucket list prioritizing items automatically."
+)]
 struct Args {
     #[clap(subcommand)]
     action: Action,
@@ -17,7 +18,7 @@ struct Args {
 enum Action {
     /// Add a new item or raise priority of an existing item.
     Add {
-         /// Name of the item
+        /// Name of the item
         name: String,
     },
 
@@ -61,7 +62,7 @@ fn main() -> Result<(), MainError> {
     let items = match args.action {
         Action::Add { name } => app::add_or_incr(items, name),
         Action::Incr { name } => app::add_or_incr(items, name),
-        Action::Note { name, note} => app::note(items, name, note),
+        Action::Note { name, note } => app::note(items, name, note),
         Action::Del { name } => app::del(items, name),
         Action::Ls { all } => app::ls(items, all),
     }?;


### PR DESCRIPTION
- Add an alias of `Result<T, BucketListError>`.
- Make an error when failed to get home directory.
- Remove duplicate expressions of `BucketListError`.
- Add `get_bucketlist_dir()`.
- `read_file()` returns an empty `IndexMap` only when the data file not found.